### PR TITLE
Agregar helpers para el manejo de formatos

### DIFF
--- a/src/components/Card/Card.astro
+++ b/src/components/Card/Card.astro
@@ -1,14 +1,10 @@
 ---
+import { formatPercentage } from "../../utils/formats"
+
 const { logo, tna, tea, detail, title, name, url } = Astro.props
 
-const tnaRate = new Intl.NumberFormat('es-AR', {
-  style: 'percent',
-  minimumFractionDigits: 2
-}).format(tna / 100)
-const teaRate = new Intl.NumberFormat('es-AR', {
-  style: 'percent',
-  minimumFractionDigits: 2
-}).format(tea / 100)
+const tnaRate = formatPercentage(tna)
+const teaRate = formatPercentage(tea)
 const logoImg = logo + '?tr=w-32,h-32,f_webp'
 ---
   <a class="bg-white shadow-sm rounded-lg border-gray-300 p-4 text-gray dark:bg-gray-900" href={`${url}?ref=comparatasas.ar`}>

--- a/src/components/Dolar.astro
+++ b/src/components/Dolar.astro
@@ -1,13 +1,9 @@
 ---
-const { name, precioCompra, precioVenta, isLastItem } = Astro.props
-const formattedCompra = new Intl.NumberFormat('es-AR', {
-  style: 'currency',
-  currency: 'ARS'
-}).format(precioCompra)
-const formattedVenta = new Intl.NumberFormat('es-AR', {
-  style: 'currency',
-  currency: 'ARS'
-}).format(precioVenta)
+import { formatCurrency } from "../utils/formats"
+
+const { name, precioCompra, precioVenta } = Astro.props
+const formattedCompra = formatCurrency(precioCompra)
+const formattedVenta = formatCurrency(precioVenta)
 ---
 
 <tr>

--- a/src/components/Dolares.astro
+++ b/src/components/Dolares.astro
@@ -42,13 +42,12 @@ const filteredDolares = data.filter((item) =>
       </thead>
       <tbody>
         {
-          filteredDolares.map((item, index) =>
+          filteredDolares.map((item) =>
             (item.compra + item.venta) / 2 > 800 ? (
               <Dolar
                 name={item.nombre}
                 precioCompra={item.compra}
                 precioVenta={item.venta}
-                isLastItem={index === filteredDolares.length - 1}
               />
             ) : null
           )

--- a/src/components/ExchangeTable/Row.astro
+++ b/src/components/ExchangeTable/Row.astro
@@ -1,10 +1,9 @@
 ---
+import { formatPercentage } from "../../utils/formats"
+
 const { isLastItem, moneda, apy, logo, defaultLogo } = Astro.props
 
-const apyFormatted = new Intl.NumberFormat('es-AR', {
-  style: 'percent',
-  minimumFractionDigits: 2
-}).format(apy / 100)
+const apyFormatted = formatPercentage(apy)
 
 const fullLogo = logo ?? defaultLogo
 ---

--- a/src/utils/formats.ts
+++ b/src/utils/formats.ts
@@ -1,0 +1,11 @@
+export const formatPercentage = (percentage: number): string =>
+  new Intl.NumberFormat('es-AR', {
+    style: 'percent',
+    minimumFractionDigits: 2
+  }).format(percentage / 100)
+
+export const formatCurrency = (amount: number): string =>
+  new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency: 'ARS'
+  }).format(amount)


### PR DESCRIPTION
- Agregué un file `formats.tsx` en la carpeta `utils` para poder centralizar en un mismo archivo el manejo de los distintos formatos (porcentaje, moneda) y evitar la repetición de código.
- Eliminé una propiedad `isLastItem` que no estaba siendo utilizada en el file `Dolar.astro`