### PR TITLE
Fix cuentas usa #103 

### DIFF
--- a/src/data/menu.ts
+++ b/src/data/menu.ts
@@ -25,7 +25,7 @@ export const menuItemsData: MenuItemType[] = [
   {
     name: 'Cuentas USA',
     url: '/cuentas-usa',
-    icon: '🇺🇸',
+    icon: '🗽',
   },
   {
     name: 'AVISO LEGAL',


### PR DESCRIPTION
Se cambió el icono del menú "Cuentas USA" ya que los emojis de banderas no están disponibles de manera nativa en los S.O Windows.

resolves #103 