### PR TITLE
Agrego link en las cards para página detalle

### DIFF
--- a/src/components/Card/Card.astro
+++ b/src/components/Card/Card.astro
@@ -2,12 +2,37 @@
 import cn from '../../utils/cn';
 import { formatPercentage } from '../../utils/formats';
 
-const { logo, tna, tea, detail, title, name, url, disableRounded, className } =
-  Astro.props;
+interface Props {
+  logo: string;
+  tna: number;
+  tea: number;
+  detail: string;
+  title?: string;
+  name: string;
+  url: string;
+  slug?: string;
+  disableRounded: boolean;
+  className: string;
+  key: number;
+}
+
+const {
+  logo,
+  tna,
+  tea,
+  detail,
+  title,
+  name,
+  url,
+  slug,
+  disableRounded,
+  className,
+} = Astro.props;
 
 const tnaRate = formatPercentage(tna);
 const teaRate = formatPercentage(tea);
 const logoImg = `${logo}?tr=w-32,h-32,f_webp`;
+const cardUrl = slug ? `detalle/${slug}` : `${url}?ref=comparatasas.ar`;
 ---
 
 <a
@@ -18,7 +43,7 @@ const logoImg = `${logo}?tr=w-32,h-32,f_webp`;
       'rounded-lg': !disableRounded,
     },
   )}
-  href={`${url}?ref=comparatasas.ar`}
+  href={cardUrl}
 >
   <div class=''>
     <div class='flex flex-row items-center justify-between'>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -50,7 +50,7 @@ const {
         .matchMedia('(prefers-color-scheme: dark)')
         .addEventListener('change', setThemeColor);
     </script>
-    <link rel='apple-touch-icon' sizes='180x180' href='apple-touch-icon.png' />
+    <link rel='apple-touch-icon' sizes='180x180' href='/apple-touch-icon.png' />
     <meta name='apple-mobile-web-app-capable' content='yes' />
     <meta name='apple-mobile-web-app-title' content='Compara Tasas' />
     <meta name='apple-mobile-web-app-status-bar-style' content='default' />
@@ -62,7 +62,7 @@ const {
     <ViewTransitions />
     <meta name='description' content={metaDescription} />
     <meta name='keywords' content={metaKeywords} />
-    <link rel='icon' href='favicon.ico' type='image/x-icon' />
+    <link rel='icon' href='/favicon.ico' type='image/x-icon' />
     <meta property='og:image' content={metaImage} />
   </head>
   <body class='bg-gray-100 text-gray-900 dark:bg-gray-950'>

--- a/src/model/business.ts
+++ b/src/model/business.ts
@@ -1,7 +1,10 @@
 export type Rate = 'TNA' | 'TEA';
 export type Currency = 'Pesos' | 'Dólares';
 export type IncomeType = 'Fija' | 'Variable' | 'Mixta';
+
+// Este tipo de dato lo usamos para los FCI
 export type FullInvestmentData = InvestmentJsonData & Omit<Investment, 'url'>;
+// Este tipo de dato lo usamos para los plazos fijos
 export type FullBankData = Omit<BankJsonData, 'nombre'> &
   Omit<Investment, 'url'>;
 
@@ -27,6 +30,7 @@ export interface Investment {
   tea: number;
 }
 
+// Tipos devueltos por la API ArgentinaDatos para los FCI
 export interface FCIResponse {
   fondo: string;
   fecha: string;
@@ -36,6 +40,7 @@ export interface FCIResponse {
   horizonte: string;
 }
 
+// Tipos devueltos por la API ArgentinaDatos para los Plazo Fijo
 export interface PlazoFijoResponse {
   entidad: string;
   logo: string;
@@ -43,6 +48,7 @@ export interface PlazoFijoResponse {
   tnaNoClientes: number;
 }
 
+// Define las propiedades y tipos que hay en la lista JSON de los FCI
 export interface InvestmentJsonData {
   nombreOficial: string;
   nombreSimplificado: string;
@@ -59,6 +65,7 @@ export interface InvestmentJsonData {
   description: string;
 }
 
+// Define las propiedades y tipos que hay en la lista JSON de los bancos
 export interface BankJsonData
   extends Omit<InvestmentJsonData, 'nombreOficial' | 'nombreSimplificado'> {
   entidad: string;

--- a/src/pages/detalle/[bank].astro
+++ b/src/pages/detalle/[bank].astro
@@ -46,6 +46,20 @@ const bank = BanksData.find((data) => data.name === name);
     id='containter'
     class='container mx-auto my-6 mb-12 max-w-sm px-4 sm:max-w-sm md:max-w-md lg:max-w-lg'
   >
+    <button class='mb-4' type='button' onclick='history.back()'>
+      <svg
+        width='24'
+        height='24'
+        viewBox='0 0 24 24'
+        class='fill-current text-neutral-900 dark:text-white'
+        xmlns='http://www.w3.org/2000/svg'
+      >
+        <title>Botón atrás</title>
+        <path
+          d='M17.835 3.86998L16.055 2.09998L6.16504 12L16.065 21.9L17.835 20.13L9.70504 12L17.835 3.86998Z'
+        ></path>
+      </svg>
+    </button>
     <div class='flex gap-4 dark:text-gray-100'>
       <img class='h-12 w-12 rounded-full' src={bank?.logo} />
       <div class='flex flex-col'>
@@ -141,7 +155,9 @@ const bank = BanksData.find((data) => data.name === name);
       >Simulá tu inversión</button
     >
     <div class='flex items-center justify-center'>
-      <a class='text-indigo-500 underline' href=''>Visitá el sitio web</a>
+      <a class='text-indigo-500 underline' target='_blank' href={bank?.url}
+        >Visitá el sitio web</a
+      >
     </div>
   </div>
 

--- a/src/pages/detalle/[instrument].astro
+++ b/src/pages/detalle/[instrument].astro
@@ -3,7 +3,6 @@ import { getFCIInvestments } from '../../Services/argentinaDatosFCI';
 import NavBar from '../../components/Menu/NavBar';
 import fciList from '../../data/fci.json';
 import Layout from '../../layouts/Layout.astro';
-
 interface paramsType {
   params: {
     instrument: string;
@@ -46,6 +45,20 @@ const fci = FCIData.find((data) => data.name === name);
     id='containter'
     class='container mx-auto my-6 mb-12 max-w-sm px-4 sm:max-w-sm md:max-w-md lg:max-w-lg'
   >
+    <button class='mb-4' type='button' onclick='history.back()'>
+      <svg
+        width='24'
+        height='24'
+        viewBox='0 0 24 24'
+        class='fill-current text-neutral-900 dark:text-white'
+        xmlns='http://www.w3.org/2000/svg'
+      >
+        <title>Botón atrás</title>
+        <path
+          d='M17.835 3.86998L16.055 2.09998L6.16504 12L16.065 21.9L17.835 20.13L9.70504 12L17.835 3.86998Z'
+        ></path>
+      </svg>
+    </button>
     <div class='flex gap-4 dark:text-gray-100'>
       <img class='h-12 w-12 rounded-full' src={fci?.logo} />
       <div class='flex flex-col'>
@@ -141,7 +154,9 @@ const fci = FCIData.find((data) => data.name === name);
       >Simulá tu inversión</button
     >
     <div class='flex items-center justify-center'>
-      <a class='text-indigo-500 underline' href=''>Visitá el sitio web</a>
+      <a class='text-indigo-500 underline' target='_blank' href={fci?.url}
+        >Visitá el sitio web</a
+      >
     </div>
   </div>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import NavBar from '../components/Menu/NavBar';
 import Banner from '../components/banner.astro';
 import { EXCHANGES } from '../data/exchanges';
 import Layout from '../layouts/Layout.astro';
-import type { Investment } from '../model/business';
+import type { FullBankData, FullInvestmentData } from '../model/business';
 import type { Return } from '../model/exchange';
 import { TYPE_INVESTMENT_PESOS_MAPPING } from '../utils/returnsMapping';
 
@@ -36,7 +36,7 @@ const pesosLinks = {
 const isPesoCoin = (value: Return) =>
   value.moneda === 'ARS' || value.moneda === 'NUARS' || value.moneda === 'NARS';
 
-const sortedPfData: Investment[] = PFData.filter((item) =>
+const sortedPfData: FullBankData[] = PFData.filter((item) =>
   pesos.includes(item.type),
 ).sort((a, b) => {
   if (a.tea < b.tea) {
@@ -48,7 +48,7 @@ const sortedPfData: Investment[] = PFData.filter((item) =>
   return 0; // return 0 if they're equal
 });
 
-const sortedFciData: Investment[] = allFciData
+const sortedFciData: FullInvestmentData[] = allFciData
   .filter((item) => pesos.includes(item.type))
   .sort((a, b) => {
     if (a.tea < b.tea) {


### PR DESCRIPTION
- Se agregaron los links que dirigen a la página /detalle en las cards de plazos fijos y FCI
- Se agregó un botón "atrás" en la página /detalle
- Se corrigió un bug que impedía que se muestre el favicon en la página detalle