### PR TITLE
Cambiar tope de remuneración de NARANJA X

### DIFF
--- a/src/data/fci.json
+++ b/src/data/fci.json
@@ -273,7 +273,7 @@
   },
   "NARANJA X": {
     "nombreOficial": "Naranja X",
-    "nombreSimplificado": "Promocion hasta $300k",
+    "nombreSimplificado": "Promocion hasta $400k",
     "logo": "https://ik.imagekit.io/ferminrp/naranja.jpeg?updatedAt=1707137279009",
     "url": "https://www.naranjax.com/cuenta-remunerada",
     "type": "cuenta_remunerada",


### PR DESCRIPTION
Naranja X aumentó el tope de remuneración a 400k. Source: https://www.naranjax.com/cuenta-remunerada
![image](https://github.com/ferminrp/compara-tasas/assets/31087818/017fc4df-47d1-4451-9066-bfccbac821ab)
