### PR TITLE
Added Takenos Fee

### DIFF
--- a/src/pages/cuentas-usa.astro
+++ b/src/pages/cuentas-usa.astro
@@ -9,7 +9,11 @@ const accounts = [
     logo: 'https://ik.imagekit.io/ferminrp/Takenos%20logo.jpeg?updatedAt=1709119639419',
     url: 'https://app.takenos.com/referral?referral=3019da20-6746-4f43-81ba-a489cd833a0d',
     attributes: {
-      'Comisión por recibir': '0%',
+      'Comisión por recibir (WIRE-USA)': '25 USD',
+      'Comisión por recibir (ACH)': '0 USD',
+      'Comisión por recibir (SWIFT < 1000 USD)': '70 USD',
+      'Comisión por recibir (SWIFT > 1000 USD)': '50 USD',
+      'Comisión por recibir (EUR)': '0 USD',
       'Comisión por extraer': '3%',
       'Cuenta USA a tu nombre': true,
       'Retiros en pesos': true,


### PR DESCRIPTION
Updated Takenos Fee's [https://help.takenos.com/en/articles/9670273-cual-es-el-costo-de-depositar-en-takenos]

¿Cuál es el costo de depositar en Takenos?
Conocé los costos de depósito en Takenos

Updated over 4 months ago
Los costos para depositar en Takenos son los siguientes:

Las transferencias WIRE-USA tienen un costo de depósito de $25USD fijo.

 

Las transferencias ACH no tienen costo de depósito.

 

Las transferencias SWIFT o WIRE internacionales tienen un costo de depósito de $70 USD para transferencias menores a $1000USD y para mayores de $1000USD tiene un costo de $50USD.

 

Los depósitos en Euros no tienen costo de depósito.