### PR TITLE
fix: enable minimap and improve axis formatting in AccountHistoryTNAChart

### DIFF
--- a/app/components/charts/AccountHistoryTNAChart.vue
+++ b/app/components/charts/AccountHistoryTNAChart.vue
@@ -4,6 +4,7 @@ import 'vue-data-ui/style.css'
 import { useChartTheme } from '~/composables/useChartConfig'
 import { useVueDataUiChart } from '~/composables/useVueDataUiChart'
 import { useVueDataUiSolidTooltip } from '~/composables/useVueDataUiSolidTooltip'
+import type { VueUiXyConfig, VueUiXyDatasetItem } from 'vue-data-ui'
 
 interface Props {
   history: AccountHistoryItem[]
@@ -23,7 +24,7 @@ function formatShortDate(iso: string) {
 
 const xLabels = computed(() => props.history.map((item) => formatShortDate(item.fecha)))
 
-const dataset = computed(() => {
+const dataset = computed<VueUiXyDatasetItem[]>(() => {
   if (!props.history.length) return []
   return [
     {
@@ -38,7 +39,7 @@ const dataset = computed(() => {
   ]
 })
 
-const chartConfig = computed(() => ({
+const chartConfig = computed<VueUiXyConfig>(() => ({
   responsive: true,
   theme: '',
   useCssAnimation: false,
@@ -48,6 +49,9 @@ const chartConfig = computed(() => ({
     color: textColor.value,
     height: 384,
     userOptions: { show: false },
+    padding: {
+      bottom: 0
+    },
     grid: {
       stroke: gridLineColor.value,
       showHorizontalLines: true,
@@ -61,10 +65,11 @@ const chartConfig = computed(() => ({
           xLabel: 'Fecha',
         },
         yAxis: {
-          formatter: (v: number | string) => `${Number(v).toFixed(1)}%`,
+          formatter: ({ value }) => `${Number(value).toFixed(1)}%`,
         },
         xAxisLabels: {
           values: xLabels.value,
+          color: textColor.value,
           rotation: -45,
           fontSize: 10,
         },
@@ -93,10 +98,9 @@ const chartConfig = computed(() => ({
     legend: { show: false, color: textColor.value },
   },
   line: {
-    area: { opacity: 0.35, useGradient: true },
+    area: { opacity: 35, useGradient: true },
     labels: { show: false },
   },
-  table: { show: false },
 }))
 </script>
 

--- a/app/components/charts/AccountHistoryTNAChart.vue
+++ b/app/components/charts/AccountHistoryTNAChart.vue
@@ -52,6 +52,16 @@ const chartConfig = computed<VueUiXyConfig>(() => ({
     padding: {
       bottom: 0
     },
+    zoom: {
+      minimap: {
+        show: true,
+        selectedColor: '#3b82f6',
+        frameColor: gridLineColor.value,
+      }
+    },
+    highlighter: {
+      color: textColor.value,
+    },
     grid: {
       stroke: gridLineColor.value,
       showHorizontalLines: true,
@@ -70,8 +80,10 @@ const chartConfig = computed<VueUiXyConfig>(() => ({
         xAxisLabels: {
           values: xLabels.value,
           color: textColor.value,
-          rotation: -45,
-          fontSize: 10,
+          autoRotate: {
+            enable: true,
+            angle: -45
+          }
         },
       },
     },


### PR DESCRIPTION
Hi, I'm the author if vue-data-ui, here are a few suggestions to fix the chart configuration in the `AccountHistoryTNAChart.vue` file.
Also fixes the NaN in the yAxis labels.

<img width="802" height="701" alt="image" src="https://github.com/user-attachments/assets/eba6c30c-03db-4f9a-ad87-a97372fc5964" />


Feel free to ignore this PR, if you prefer to fix it yourself :)

I also recommend you use the treeshaken imports:

instead of 

```js
import { VueUiXy } from "vue-data-ui" // all the components of the library will be in your build (legacy importing)
```

use:
```js
import { VueUiXy } from "vue-data-ui/vue-ui-xy" // treeshaken import
```
So I recommend you rework the `useVueDataUiChart` composable so it treeshakes components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **New Features**
  * Se agregaron controles de zoom con minimapa interactivo al gráfico de historial.
  * Nuevo resaltador de datos personalizable.

* **Improvements**
  * Formato mejorado de ejes para mejor legibilidad.
  * Etiquetas del eje X con rotación automática optimizada.
  * Estilos visuales del gráfico refinados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->