### PR TITLE
fix: serialize sorting state as JSON in fondos URL query

### DIFF
--- a/app/pages/fondos/index.vue
+++ b/app/pages/fondos/index.vue
@@ -723,23 +723,37 @@ const columns: TableColumn<FundSeriesRow>[] = [
 ]
 
 // Estado de ordenamiento
-const sorting = useRouteQuery(
-  'sort',
-  [
-    {
-      id: 'fondo',
-      desc: false,
-    },
-  ],
-  {
-    transform: (value: any) => {
-      try {
-        return typeof value === 'string' ? JSON.parse(value) : value
-      } catch {
-        return value
-      }
-    },
+const sortQuery = useRouteQuery<string>('sort', '[{"id":"fondo","desc":false}]')
+
+type SortingState = Array<{ id: string; desc: boolean }>
+
+function parseSorting(value: string): SortingState {
+  try {
+    const parsed = JSON.parse(value)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return [{ id: 'fondo', desc: false }]
+  }
+}
+
+const sorting = ref<SortingState>(parseSorting(sortQuery.value))
+
+watch(sortQuery, (value) => {
+  const next = parseSorting(value)
+  if (JSON.stringify(next) !== JSON.stringify(sorting.value)) {
+    sorting.value = next
+  }
+})
+
+watch(
+  sorting,
+  (value) => {
+    const serialized = JSON.stringify(value ?? [])
+    if (sortQuery.value !== serialized) {
+      sortQuery.value = serialized
+    }
   },
+  { deep: true },
 )
 </script>
 


### PR DESCRIPTION
## Problema

Al ordenar la tabla de fondos, la URL quedaba con un filtro corrupto:

- **Antes:** `/fondos?sort=[object+Object]`
- **Después:** `/fondos?sort=[{"id":"tna","desc":true}]`

**Causa raíz:** `useRouteQuery('sort', [...])` recibía un **array de objetos** como valor del parámetro. Al escribir en la URL, Vue Router serializaba cada elemento con `String()` → `[object Object]`. El `transform` con `JSON.parse` que había en el código solo resolvía la lectura, no la escritura.

**Consecuencias:** además de la URL inválida, el orden elegido **no persistía** al recargar o compartir la página, y las URLs rotas ya compartidas rompían el estado de ordenamiento.

## Solución

Se reemplazó por el patrón de sincronización bidireccional ya existente en `app/pages/remesas.vue` (el repo ya tenía el patrón correcto en otra página):

- El estado de ordenamiento se serializa como **string JSON** en la URL: `?sort=[{"id":"tna","desc":true}]`
- `parseSorting()` lee y valida el valor, con **fallback al orden default** si viene corrupto (cubre las URLs viejas con `[object Object]` ya compartidas)
- Dos `watch` sincronizan URL ↔ estado de la tabla (sin loops de actualización)
- `useRouteQuery<string>` tipa explícitamente el ref, evitando el error TS de inferencia de literal: `Type 'string' is not assignable to type '"[{\"id\":\"fondo\",\"desc\":false}]"'`

## Verificación

- [x] `pnpm lint` pasa sobre `app/pages/fondos/index.vue`
- [x] `nuxi typecheck`: sin errores nuevos en el archivo (los preexistentes quedan fuera de scope)
- [x] Probado en dev server: el orden persiste en la URL y sobrevive a recargas y a compartir el enlace
- [x] URLs viejas con `?sort=[object Object]` caen al orden default sin romper la tabla

## Notas

- El archivo tiene errores de tipos **preexistentes** con el mismo patrón de literales (`page`/`pageSize`, líneas 171 y 183) — fuera del scope de este PR.
- `app/pages/remesas.vue` tiene el mismo bug latente de serialización (mismo patrón, sin typecheck en el CI) — se puede arreglar en un PR aparte.

---

Hecho por DeepSeek V4 flash (0731)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Mejoras**
  * El ordenamiento de la tabla ahora se conserva correctamente en la URL.
  * Se validan los criterios de ordenamiento para evitar valores no válidos.
  * Los cambios de orden se sincronizan automáticamente entre la tabla y la URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->